### PR TITLE
Upgrades to Cycle Unified

### DIFF
--- a/index.es
+++ b/index.es
@@ -1,4 +1,5 @@
 import xstream from "xstream"
+import {adapt} from '@cycle/run/lib/adapt'
 import domEvents from "dom-events"
 import {supportsHistory} from "history/lib/DOMUtils"
 import {useQueries, createHashHistory, createHistory, useBasename} from "history"
@@ -172,7 +173,7 @@ function makePageDriver(options = {}) {
 
     let unsubscrbe
 
-    return xstream.create({
+    const page$ = xstream.create({
       start: function startPageStream(listener) {
         
         // hack??
@@ -193,6 +194,8 @@ function makePageDriver(options = {}) {
         unsubscrbe()
       }
     })
+
+    return adapt(page$)
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -4,16 +4,19 @@
   "description": "Tiny client-side router for Cycle.js",
   "version": "1.3.0",
   "dependencies": {
+    "@cycle/run": "^3.0.0",
     "dom-events": "^0.1.1",
     "global-object": "^1.0.0",
     "history": "^3.0.0",
     "path-to-regexp": "^1.5.3",
-    "xstream": "^5.3.2"
+    "xstream": "^10.3.0"
   },
   "devDependencies": {
-    "@cycle/xstream-run": "^3.0.4",
     "babel-preset-es2015": "^6.13.2",
-    "babelify": "^7.3.0"
+    "babelify": "^7.3.0",
+    "browserify": "^14.1.0",
+    "mocha": "^3.2.0",
+    "testem": "=1.9.1"
   },
   "author": "Garry",
   "keywords": [

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-import Cycle from "@cycle/xstream-run"
+import {run, setup} from "@cycle/run"
 import xstream from "xstream"
 import {makePageDriver, Action} from "../index"
 import assert from "assert"
@@ -19,25 +19,25 @@ describe("cycle-page", () => {
 
   it("should change url.", () => {
     const pathname = location.pathname, page = makePageDriver()
-    Cycle.run(main, { page })
+    run(main, { page })
     assert.notStrictEqual(location.pathname, pathname)
   })
 
   it("should navigate url by hash fragment when option.hash == true.", () => {
     const page = makePageDriver({ hash: true })
-    Cycle.run(main, { page })
+    run(main, { page })
     assert.strictEqual(location.hash, "#/test")
   })
 
   it("should contains basename.", () => {
     const page = makePageDriver({ baseName: "cycle" })
-    Cycle.run(main, { page })
+    run(main, { page })
     assert.strictEqual(location.pathname, "/cycle/test")
   })
 
   it("should send an Context when history changed.", done => {
 
-    const {sources, run} = Cycle(main, {
+    const {sources, run} = setup(main, {
       page: makePageDriver()
     })
 
@@ -78,7 +78,7 @@ describe("cycle-page", () => {
       }
     }
     
-    const {sources, run} = Cycle(main, {
+    const {sources, run} = setup(main, {
       page: makePageDriver({
         patterns: {
           test: "/test/:id"
@@ -100,7 +100,7 @@ describe("cycle-page", () => {
 
   it("should capture link clicks when option.click === true", () => {
 
-    Cycle.run(main, {
+    run(main, {
       page: makePageDriver({
         click: true
       })
@@ -132,7 +132,7 @@ describe("cycle-page", () => {
   //     }
   //   }
 
-  //   Cycle.run(main, {
+  //   run(main, {
   //     page: makePageDriver()
   //   })
   // })


### PR DESCRIPTION
This was a pretty easy upgrade, the only required changes was to the tests.

In index.es I did import cycle/run/lib/adapt so that (in theory) this could be used with more than just xstream, but I haven't tested that. You could remove the changes to index.es if you only wanted this library to be compatible with xstream.